### PR TITLE
Removed Mono.Runtime check when checking for WellFormedUri

### DIFF
--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -223,24 +223,13 @@ namespace RedditSharp
         public virtual HttpWebRequest CreateRequest(string url, string method)
         {
             EnforceRateLimit();
-            bool prependDomain;
-            // IsWellFormedUristring returns true on Mono for some reason when using a string like "/api/me"
-            if (Type.GetType("Mono.Runtime") != null)
-                prependDomain = !url.StartsWith("http://") && !url.StartsWith("https://");
-            else
-                prependDomain = !Uri.IsWellFormedUriString(url, UriKind.Absolute);
-
+            bool prependDomain = !Uri.IsWellFormedUriString(url, UriKind.Absolute);
             HttpWebRequest request;
             if (prependDomain)
                 request = (HttpWebRequest)WebRequest.Create(string.Format("{0}://{1}{2}", Protocol, RootDomain, url));
             else
                 request = (HttpWebRequest)WebRequest.Create(url);
             request.CookieContainer = Cookies;
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                var cookieHeader = Cookies.GetCookieHeader(new Uri("http://reddit.com"));
-                request.Headers.Set("Cookie", cookieHeader);
-            }
             if (IsOAuth())// use OAuth
             {
                 request.Headers.Set("Authorization", "bearer " + AccessToken);//Must be included in OAuth calls


### PR DESCRIPTION
Addresses issue #31 

It appears the issue referenced in this comment does not occur in the version of mono I was running (4.4.1)
https://github.com/CrustyJew/RedditSharp/blob/master/RedditSharp/WebAgent.cs#L227
```
// IsWellFormedUristring returns true on Mono for some reason when using a string like "/api/me"
```

removing the checks for the mono runtime resolved issue #31 

Likely will need some further testing by people using the latest mono runtime to ensure this does not cause issues. Could push this to a preview release on nuget for testing