### PR TITLE
Enforce rate limit only on executed requests

### DIFF
--- a/RedditSharp/BotWebAgent.cs
+++ b/RedditSharp/BotWebAgent.cs
@@ -32,7 +32,6 @@ namespace RedditSharp
         {
             Username = username;
             Password = password;
-            EnableRateLimit = true;
             RateLimit = RateLimitMode.Burst;
             RootDomain = "oauth.reddit.com";
             TokenProvider = new AuthProvider(clientID, clientSecret, redirectURI, this);

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -25,12 +25,6 @@ namespace RedditSharp
         public static string UserAgent { get; set; }
 
         /// <summary>
-        /// It is strongly advised that you leave this enabled. Reddit bans excessive
-        /// requests with extreme predjudice.
-        /// </summary>
-        public static bool EnableRateLimit { get; set; }
-
-        /// <summary>
         /// web protocol "http", "https"
         /// </summary>
         public static string Protocol { get; set; }
@@ -100,18 +94,17 @@ namespace RedditSharp
             get { return _requestsThisBurst; }
         }
 
-
-        static WebAgent()
-        {
+        static WebAgent() {
             //Static constructors are dumb, no likey -Meepster23
             UserAgent = string.IsNullOrWhiteSpace( UserAgent ) ? "" : UserAgent ;
             Protocol = string.IsNullOrWhiteSpace(Protocol) ? "https" : Protocol;
             RootDomain = string.IsNullOrWhiteSpace(RootDomain) ? "www.reddit.com" : RootDomain;
             _httpClient = new HttpClient();
         }
-        public WebAgent() {
 
+        public WebAgent() {
         }
+
         /// <summary>
         /// Intializes a WebAgent with a specified access token and sets the default url to the oauth api address
         /// </summary>
@@ -167,7 +160,6 @@ namespace RedditSharp
                 json = JToken.Parse("{'method':'" + response.RequestMessage.Method + "','uri':'" + response.RequestMessage.RequestUri.AbsoluteUri + "','status':'" + response.StatusCode.ToString() + "'}");
             }
             return json;
-
         }
 
         /// <summary>
@@ -229,7 +221,6 @@ namespace RedditSharp
         /// <returns></returns>
         public virtual HttpRequestMessage CreateRequest(string url, string method)
         {
-            EnforceRateLimit();
             bool prependDomain;
             // IsWellFormedUristring returns true on Mono for some reason when using a string like "/api/me"
             if (Type.GetType("Mono.Runtime") != null)
@@ -265,7 +256,6 @@ namespace RedditSharp
         /// <returns></returns>
         protected virtual HttpRequestMessage CreateRequest(Uri uri, string method)
         {
-            EnforceRateLimit();
             var request = new HttpRequestMessage();
             request.RequestUri = uri;
             if (IsOAuth())// use OAuth

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -167,7 +167,7 @@ namespace RedditSharp
             lock (rateLimitLock) {
                 // Note: Do not use ConfigureAwait here, it must be in the same
                 // thread context for the lock to release properly
-                rateLimitTask = Task.Delay(250);
+                rateLimitTask = Task.Delay(msec);
             }
             await rateLimitTask;
             lock (rateLimitLock) {


### PR DESCRIPTION
The rate limit is only on executed requests, not created. As it currently stands, one request to reddit counts as two towards the rate limit: once for creating the request, and once for executing it. I removed the calls to it in CreateRequest.

EnableRateLimit also seems to be unused in favor of RateLimitMode.None, so I removed it.

Also changed EnforceRateLimit to not block the thread while it waits for the rate limit to clear. This has not been fully tested.

A potential thing to look into is using the Reddit rate limit headers for this instead: https://github.com/reddit/reddit/wiki/API