### PR TITLE
Fix ArgumentNullException on any RedditObject creation

### DIFF
--- a/RedditSharp/RedditObject.cs
+++ b/RedditSharp/RedditObject.cs
@@ -11,7 +11,7 @@ namespace RedditSharp {
       public IWebAgent WebAgent => Reddit?.WebAgent;
 
       public RedditObject(Reddit reddit) {
-          if (Reddit == null)
+          if (reddit == null)
             throw new ArgumentNullException(nameof(reddit));
           Reddit = reddit;
       }


### PR DESCRIPTION
Constructor currently uses the property it's supposed to assign to instead of the constructor parameter for null-checks, leading every call to result in a thrown exception.