### PR TITLE
Update to DateTimeOffset.

### DIFF
--- a/RedditSharp/BotWebAgent.cs
+++ b/RedditSharp/BotWebAgent.cs
@@ -15,9 +15,9 @@ namespace RedditSharp
         private string Password;
 
         /// <summary>
-        /// DateTime the token expires.
+        /// Date and time the token expires.
         /// </summary>
-        public DateTime TokenValidTo { get; set; }
+        public DateTimeOffset TokenValidTo { get; set; }
 
         /// <summary>
         /// A web agent using reddit's OAuth interface.
@@ -42,7 +42,7 @@ namespace RedditSharp
         public override HttpWebRequest CreateRequest(string url, string method)
         {
             //add 5 minutes for clock skew to ensure requests succeed 
-            if (url != AuthProvider.AccessUrl && DateTime.UtcNow.AddMinutes(5) > TokenValidTo)
+            if (url != AuthProvider.AccessUrl && DateTimeOffset.UtcNow.AddMinutes(5) > TokenValidTo)
             {
                 GetNewToken();
             }
@@ -53,7 +53,7 @@ namespace RedditSharp
         protected override HttpWebRequest CreateRequest(Uri uri, string method)
         {
             //add 5 minutes for clock skew to ensure requests succeed
-            if (uri.ToString() != AuthProvider.AccessUrl && DateTime.UtcNow.AddMinutes(5) > TokenValidTo)
+            if (uri.ToString() != AuthProvider.AccessUrl && DateTimeOffset.UtcNow.AddMinutes(5) > TokenValidTo)
             {
                 GetNewToken();
             }
@@ -63,7 +63,7 @@ namespace RedditSharp
         private void GetNewToken()
         {
             AccessToken = TokenProvider.GetOAuthToken(Username, Password);
-            TokenValidTo = DateTime.UtcNow.AddHours(1);
+            TokenValidTo = DateTimeOffset.UtcNow.AddHours(1);
         }
     }
 

--- a/RedditSharp/Multi/MData.cs
+++ b/RedditSharp/Multi/MData.cs
@@ -42,7 +42,7 @@ namespace RedditSharp.Multi
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? Created { get; set; }
+        public DateTimeOffset? Created { get; set; }
 
         /// <summary>
         /// Where the multi was copied from if it was copied
@@ -67,7 +67,7 @@ namespace RedditSharp.Multi
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? CreatedUTC { get; set; }
+        public DateTimeOffset? CreatedUTC { get; set; }
 
         /// <summary>
         /// Hex Code of the color for the multi

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -554,8 +554,8 @@ namespace RedditSharp
         /// Return a <see cref="Listing{T}"/> of items matching search with a given time period.
         /// </summary>
         /// <typeparam name="T"><see cref="Thing"/></typeparam>
-        /// <param name="from">DateTime when to begin. </param>
-        /// <param name="to">DateTime when to end. </param>
+        /// <param name="from">When to begin. </param>
+        /// <param name="to">When to end. </param>
         /// <param name="query">string to query</param>
         /// <param name="subreddit">subreddit in which to search</param>
         /// <param name="sortE">Order by <see cref="Sorting"/></param>
@@ -563,18 +563,31 @@ namespace RedditSharp
         /// <returns></returns>
         public Listing<T> SearchByTimestamp<T>(DateTime from, DateTime to, string query = "", string subreddit = "", Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All) where T : Thing
         {
+            return SearchByTimestamp<T>(new DateTimeOffset(from), new DateTimeOffset(to), query, subreddit, sortE, timeE);
+        }
+
+        /// <summary>
+        /// Return a <see cref="Listing{T}"/> of items matching search with a given time period.
+        /// </summary>
+        /// <typeparam name="T"><see cref="Thing"/></typeparam>
+        /// <param name="from">When to begin. </param>
+        /// <param name="to">When to end. </param>
+        /// <param name="query">string to query</param>
+        /// <param name="subreddit">subreddit in which to search</param>
+        /// <param name="sortE">Order by <see cref="Sorting"/></param>
+        /// <param name="timeE">Order by <see cref="TimeSorting"/></param>
+        /// <returns></returns>
+        public Listing<T> SearchByTimestamp<T>(DateTimeOffset from, DateTimeOffset to, string query = "", string subreddit = "", Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All) where T : Thing
+        {
             string sort = sortE.ToString().ToLower();
             string time = timeE.ToString().ToLower();
-            DateTimeOffset fromDto = new DateTimeOffset(from);
-            DateTimeOffset toDto = new DateTimeOffset(to);
-                        
-            var fromUnix = fromDto.ToUnixTimeSeconds();
-            var toUnix = toDto.ToUnixTimeSeconds();
+
+            var fromUnix = from.ToUnixTimeSeconds();
+            var toUnix = to.ToUnixTimeSeconds();
 
             string searchQuery = "(and+timestamp:" + fromUnix + ".." + toUnix + "+'" + query + "'+" + "subreddit:'" + subreddit + "')&syntax=cloudsearch";
             return new Listing<T>(this, string.Format(SearchUrl, searchQuery, sort, time), WebAgent);
         }
-
 
         #region SubredditSearching
 

--- a/RedditSharp/TBUserNote.cs
+++ b/RedditSharp/TBUserNote.cs
@@ -12,14 +12,6 @@ namespace RedditSharp
         public string Message { get; set; }
         public string AppliesToUsername { get; set; }
         public string Url { get; set; }
-        private DateTime _timestamp;
-        public DateTime Timestamp
-        {
-            get { return _timestamp; }
-            set
-            {
-                _timestamp = DateTime.SpecifyKind(value, DateTimeKind.Utc);
-            }
-        }
+        public DateTimeOffset Timestamp { get; set; }
     }
 }

--- a/RedditSharp/Things/BannedUser.cs
+++ b/RedditSharp/Things/BannedUser.cs
@@ -12,7 +12,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("date")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? TimeStamp { get; set; }
+        public DateTimeOffset? TimeStamp { get; set; }
 
         /// <summary>
         /// Ban note.

--- a/RedditSharp/Things/Contributor.cs
+++ b/RedditSharp/Things/Contributor.cs
@@ -18,7 +18,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("date")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime DateAdded { get; set; }
+        public DateTimeOffset DateAdded { get; set; }
 
         /// <summary>
         /// Initialize.

--- a/RedditSharp/Things/CreatedThing.cs
+++ b/RedditSharp/Things/CreatedThing.cs
@@ -41,14 +41,14 @@ namespace RedditSharp.Things
         }
 
         /// <summary>
-        /// DateTime when the item was created.
+        /// Date and time when the item was created.
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
         public DateTimeOffset Created { get; set; }
 
         /// <summary>
-        /// DateTime when the item was created in UTC.
+        /// Date and time when the item was created in UTC.
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]

--- a/RedditSharp/Things/CreatedThing.cs
+++ b/RedditSharp/Things/CreatedThing.cs
@@ -45,13 +45,13 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime Created { get; set; }
+        public DateTimeOffset Created { get; set; }
 
         /// <summary>
         /// DateTime when the item was created in UTC.
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime CreatedUTC { get; set; }
+        public DateTimeOffset CreatedUTC { get; set; }
     }
 }

--- a/RedditSharp/Things/ModAction.cs
+++ b/RedditSharp/Things/ModAction.cs
@@ -18,7 +18,7 @@ namespace RedditSharp.Things
         public ModActionType Action { get; set; }
 
         /// <summary>
-        /// DateTime of the action.
+        /// Date and time of the action.
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]

--- a/RedditSharp/Things/ModAction.cs
+++ b/RedditSharp/Things/ModAction.cs
@@ -22,7 +22,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? TimeStamp { get; set; }
+        public DateTimeOffset? TimeStamp { get; set; }
 
         /// <summary>
         /// Populated when <see cref="Action"/> is WikiBan, BanUser, or UnBanUser.

--- a/RedditSharp/Things/PrivateMessage.cs
+++ b/RedditSharp/Things/PrivateMessage.cs
@@ -33,14 +33,14 @@ namespace RedditSharp.Things
         public bool IsComment { get; set; }
 
         /// <summary>
-        /// DateTime message was sent.
+        /// Date and time message was sent.
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
         public DateTimeOffset Sent { get; set; }
 
         /// <summary>
-        /// DateTime message was sent in UTC.
+        /// Date and time message was sent in UTC.
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]

--- a/RedditSharp/Things/PrivateMessage.cs
+++ b/RedditSharp/Things/PrivateMessage.cs
@@ -37,14 +37,14 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime Sent { get; set; }
+        public DateTimeOffset Sent { get; set; }
 
         /// <summary>
         /// DateTime message was sent in UTC.
         /// </summary>
         [JsonProperty("created_utc")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime SentUTC { get; set; }
+        public DateTimeOffset SentUTC { get; set; }
 
         /// <summary>
         /// Destination user or subreddit name.

--- a/RedditSharp/Things/RedditUser.cs
+++ b/RedditSharp/Things/RedditUser.cs
@@ -90,7 +90,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime Created { get; set; }
+        public DateTimeOffset Created { get; set; }
 
         /// <summary>
         /// Return the users overview.

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -291,10 +291,23 @@ namespace RedditSharp.Things
         /// <returns>A list of posts in the range of time/dates in a specific order</returns>
         public Listing<Post> Search(DateTime from, DateTime to, Sorting sortE = Sorting.New)
         {
+            return Search(new DateTimeOffset(from), new DateTimeOffset(to), sortE);
+        }
+
+        /// <summary>
+        /// Search for a list of posts from a specific time to another time
+        /// </summary>
+        /// <param name="from">Time to begin search</param>
+        /// <param name="to">Time to end search at</param>
+        /// <param name="sortE">Sort of the objects you want to have it in</param>
+        /// <returns>A list of posts in the range of time/dates in a specific order</returns>
+        public Listing<Post> Search(DateTimeOffset from, DateTimeOffset to, Sorting sortE = Sorting.New)
+        {
             string sort = sortE.ToString().ToLower();
 
-            return new Listing<Post>(Reddit, string.Format(SearchUrlDate, Name, new DateTimeOffset(from).ToUnixTimeSeconds(), new DateTimeOffset(to).ToUnixTimeSeconds(), sort), WebAgent);
+            return new Listing<Post>(Reddit, string.Format(SearchUrlDate, Name, from.ToUnixTimeSeconds(), to.ToUnixTimeSeconds(), sort), WebAgent);
         }
+
         /// <summary>
         /// Settings of the subreddit, as best as possible
         /// </summary>

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -60,7 +60,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? Created { get; set; }
+        public DateTimeOffset? Created { get; set; }
 
         /// <summary>
         /// Subreddit description.

--- a/RedditSharp/Things/Thing.cs
+++ b/RedditSharp/Things/Thing.cs
@@ -20,7 +20,7 @@ namespace RedditSharp.Things
             FullName = data["name"].ValueOrDefault<string>();
             Id = data["id"].ValueOrDefault<string>();
             Kind = json["kind"].ValueOrDefault<string>();
-            FetchedAt = DateTime.Now;
+            FetchedAt = DateTimeOffset.Now;
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace RedditSharp.Things
         /// <summary>
         /// The time at which this object was fetched from reddit servers.
         /// </summary>
-        public DateTime FetchedAt { get; private set; }
+        public DateTimeOffset FetchedAt { get; private set; }
 
         /// <summary>
         /// Gets the time since last fetch from reddit servers.
@@ -58,7 +58,7 @@ namespace RedditSharp.Things
         {
             get
             {
-                return DateTime.Now - FetchedAt;
+                return DateTimeOffset.Now - FetchedAt;
             }
         }
         // Awaitables don't have to be called asyncronously

--- a/RedditSharp/Things/WikiPageRevision.cs
+++ b/RedditSharp/Things/WikiPageRevision.cs
@@ -14,7 +14,7 @@ namespace RedditSharp.Things
         new public string Id { get; private set; }
 
         /// <summary>
-        /// DateTime of the revision.
+        /// DateTimeOffset of the revision.
         /// </summary>
         [JsonProperty("timestamp")]
         [JsonConverter(typeof(UnixTimestampConverter))]

--- a/RedditSharp/Things/WikiPageRevision.cs
+++ b/RedditSharp/Things/WikiPageRevision.cs
@@ -18,7 +18,7 @@ namespace RedditSharp.Things
         /// </summary>
         [JsonProperty("timestamp")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? TimeStamp { get; set; }
+        public DateTimeOffset? TimeStamp { get; set; }
 
         /// <summary>
         /// Reason for the revision.

--- a/RedditSharp/ToolBoxUserNotes.cs
+++ b/RedditSharp/ToolBoxUserNotes.cs
@@ -62,7 +62,7 @@ namespace RedditSharp
                             NoteTypeIndex = note["w"].Value<int>(),
                             NoteType = warnings[note["w"].Value<int>()],
                             Message = note["n"].Value<string>(),
-                            Timestamp = DateTimeOffset.FromUnixTimeSeconds(note["t"].Value<long>()).DateTime,
+                            Timestamp = DateTimeOffset.FromUnixTimeSeconds(note["t"].Value<long>()),
                             Url = UnsquashLink(subName, note["l"].ValueOrDefault<string>()),
                         };
                         toReturn.Add(uNote);

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -72,20 +72,20 @@ namespace RedditSharp
         public CookieContainer Cookies { get; set; }
         public string AuthCookie { get; set; }
 
-        private static DateTime _lastRequest;
-        private static DateTime _burstStart;
+        private static DateTimeOffset _lastRequest;
+        private static DateTimeOffset _burstStart;
         private static int _requestsThisBurst;
         /// <summary>
-        /// UTC DateTime of last request made to Reddit API
+        /// UTC date and time of last request made to Reddit API
         /// </summary>
-        public DateTime LastRequest
+        public DateTimeOffset LastRequest
         {
             get { return _lastRequest; }
         }
         /// <summary>
-        /// UTC DateTime of when the last burst started
+        /// UTC date and time of when the last burst started
         /// </summary>
-        public DateTime BurstStart
+        public DateTimeOffset BurstStart
         {
             get { return _burstStart; }
         }
@@ -208,40 +208,40 @@ namespace RedditSharp
             switch (RateLimit)
             {
                 case RateLimitMode.Pace:
-                    while ((DateTime.UtcNow - _lastRequest).TotalSeconds < 60.0 / limitRequestsPerMinute)// Rate limiting
+                    while ((DateTimeOffset.UtcNow - _lastRequest).TotalSeconds < 60.0 / limitRequestsPerMinute)// Rate limiting
                         Thread.Sleep(250);
-                    _lastRequest = DateTime.UtcNow;
+                    _lastRequest = DateTimeOffset.UtcNow;
                     break;
                 case RateLimitMode.SmallBurst:
-                    if (_requestsThisBurst == 0 || (DateTime.UtcNow - _burstStart).TotalSeconds >= 10) //this is first request OR the burst expired
+                    if (_requestsThisBurst == 0 || (DateTimeOffset.UtcNow - _burstStart).TotalSeconds >= 10) //this is first request OR the burst expired
                     {
-                        _burstStart = DateTime.UtcNow;
+                        _burstStart = DateTimeOffset.UtcNow;
                         _requestsThisBurst = 0;
                     }
                     if (_requestsThisBurst >= limitRequestsPerMinute / 6.0) //limit has been reached
                     {
-                        while ((DateTime.UtcNow - _burstStart).TotalSeconds < 10)
+                        while ((DateTimeOffset.UtcNow - _burstStart).TotalSeconds < 10)
                             Thread.Sleep(250);
-                        _burstStart = DateTime.UtcNow;
+                        _burstStart = DateTimeOffset.UtcNow;
                         _requestsThisBurst = 0;
                     }
-                    _lastRequest = DateTime.UtcNow;
+                    _lastRequest = DateTimeOffset.UtcNow;
                     _requestsThisBurst++;
                     break;
                 case RateLimitMode.Burst:
-                    if (_requestsThisBurst == 0 || (DateTime.UtcNow - _burstStart).TotalSeconds >= 60) //this is first request OR the burst expired
+                    if (_requestsThisBurst == 0 || (DateTimeOffset.UtcNow - _burstStart).TotalSeconds >= 60) //this is first request OR the burst expired
                     {
-                        _burstStart = DateTime.UtcNow;
+                        _burstStart = DateTimeOffset.UtcNow;
                         _requestsThisBurst = 0;
                     }
                     if (_requestsThisBurst >= limitRequestsPerMinute) //limit has been reached
                     {
-                        while ((DateTime.UtcNow - _burstStart).TotalSeconds < 60)
+                        while ((DateTimeOffset.UtcNow - _burstStart).TotalSeconds < 60)
                             Thread.Sleep(250);
-                        _burstStart = DateTime.UtcNow;
+                        _burstStart = DateTimeOffset.UtcNow;
                         _requestsThisBurst = 0;
                     }
-                    _lastRequest = DateTime.UtcNow;
+                    _lastRequest = DateTimeOffset.UtcNow;
                     _requestsThisBurst++;
                     break;
             }

--- a/RedditSharp/Wiki/WikiPage.cs
+++ b/RedditSharp/Wiki/WikiPage.cs
@@ -19,7 +19,7 @@ namespace RedditSharp
         /// </summary>
         [JsonProperty("revision_date")]
         [JsonConverter(typeof(UnixTimestampConverter))]
-        public DateTime? RevisionDate { get; set; }
+        public DateTimeOffset? RevisionDate { get; set; }
 
         /// <summary>
         /// Content of the page.


### PR DESCRIPTION
The most recent commit changed the UnixTimestampConverter from DateTime to DateTimeOffset. It did not however, change all of the fields relying on the UnixTimestampConverter to the DateTimeOffset object. This means that the library currently crashes whenever it tries to load an object from a json file.  In order to fix this, this commit changes all of these fields to DateTimeOffsets.

In addition, there were various other fields and methods, such as Thing.FetchedAt and Thing.SearchByTimeStamp, that still used the DateTime type. All of these were changed to use DateTimeOffset. Even though these fields/methods do not rely on the UnixTimestampConverter, I figured that if we were going to use DateTimeOffset for the UnixTimestampConverter, might as well use it for everything else.