### PR TITLE
Spam and edited feature

### DIFF
--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -23,7 +23,9 @@ namespace RedditSharp.Things
         private const string GetReducedSettingsUrl = "/r/{0}/about.json";
         private const string ModqueueUrl = "/r/{0}/about/modqueue.json";
         private const string UnmoderatedUrl = "/r/{0}/about/unmoderated.json";
-        private const string FlairTemplateUrl = "/api/flairtemplate";
+		private const string SpamUrl = "/r/{0}/about/spam.json";
+		private const string EditedUrl = "/r/{0}/about/edited.json";
+		private const string FlairTemplateUrl = "/api/flairtemplate";
         private const string ClearFlairTemplatesUrl = "/api/clearflairtemplates";
         private const string SetUserFlairUrl = "/api/flair";
         private const string StylesheetUrl = "/r/{0}/about/stylesheet.json";
@@ -268,14 +270,37 @@ namespace RedditSharp.Things
                 return new Listing<Post>(Reddit, string.Format(UnmoderatedUrl, Name), WebAgent);
             }
         }
-        /// <summary>
-        /// Search using specific terms from a specified time to now
-        /// </summary>
-        /// <param name="terms">Terms you want to search for</param>
-        /// <param name="sortE">Sort the way you want to, see <see cref="Sorting"/></param>
-        /// <param name="timeE">Time sorting you want to see</param>
-        /// <returns>A list of posts</returns>
-        public Listing<Post> Search(string terms, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All)
+
+		/// <summary>
+		/// Listing of things that have been removed from the subreddit.
+		/// </summary>
+		public Listing<VotableThing> Spam
+		{
+			get
+			{
+				return new Listing<VotableThing>(Reddit, string.Format(SpamUrl, Name), WebAgent);
+			}
+		}
+
+		/// <summary>
+		/// Listing of things that have been edited
+		/// </summary>
+		public Listing<VotableThing> Edited
+		{
+			get
+			{
+				return new Listing<VotableThing>(Reddit, string.Format(EditedUrl, Name), WebAgent);
+			}
+		}
+
+		/// <summary>
+		/// Search using specific terms from a specified time to now
+		/// </summary>
+		/// <param name="terms">Terms you want to search for</param>
+		/// <param name="sortE">Sort the way you want to, see <see cref="Sorting"/></param>
+		/// <param name="timeE">Time sorting you want to see</param>
+		/// <returns>A list of posts</returns>
+		public Listing<Post> Search(string terms, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All)
         {
             string sort = sortE.ToString().ToLower();
             string time = timeE.ToString().ToLower();

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -23,9 +23,9 @@ namespace RedditSharp.Things
         private const string GetReducedSettingsUrl = "/r/{0}/about.json";
         private const string ModqueueUrl = "/r/{0}/about/modqueue.json";
         private const string UnmoderatedUrl = "/r/{0}/about/unmoderated.json";
-		private const string SpamUrl = "/r/{0}/about/spam.json";
-		private const string EditedUrl = "/r/{0}/about/edited.json";
-		private const string FlairTemplateUrl = "/api/flairtemplate";
+        private const string SpamUrl = "/r/{0}/about/spam.json";
+        private const string EditedUrl = "/r/{0}/about/edited.json";
+        private const string FlairTemplateUrl = "/api/flairtemplate";
         private const string ClearFlairTemplatesUrl = "/api/clearflairtemplates";
         private const string SetUserFlairUrl = "/api/flair";
         private const string StylesheetUrl = "/r/{0}/about/stylesheet.json";
@@ -271,36 +271,36 @@ namespace RedditSharp.Things
             }
         }
 
-		/// <summary>
-		/// Listing of things that have been removed from the subreddit.
-		/// </summary>
-		public Listing<VotableThing> Spam
-		{
-			get
-			{
-				return new Listing<VotableThing>(Reddit, string.Format(SpamUrl, Name), WebAgent);
-			}
-		}
+        /// <summary>
+        /// Listing of things that have been removed from the subreddit.
+        /// </summary>
+        public Listing<VotableThing> Spam
+        {
+            get
+            {
+                return new Listing<VotableThing>(Reddit, string.Format(SpamUrl, Name), WebAgent);
+            }
+        }
 
-		/// <summary>
-		/// Listing of things that have been edited
-		/// </summary>
-		public Listing<VotableThing> Edited
-		{
-			get
-			{
-				return new Listing<VotableThing>(Reddit, string.Format(EditedUrl, Name), WebAgent);
-			}
-		}
+        /// <summary>
+        /// Listing of things that have been edited
+        /// </summary>
+        public Listing<VotableThing> Edited
+        {
+            get
+            {
+                return new Listing<VotableThing>(Reddit, string.Format(EditedUrl, Name), WebAgent);
+            }
+        }
 
-		/// <summary>
-		/// Search using specific terms from a specified time to now
-		/// </summary>
-		/// <param name="terms">Terms you want to search for</param>
-		/// <param name="sortE">Sort the way you want to, see <see cref="Sorting"/></param>
-		/// <param name="timeE">Time sorting you want to see</param>
-		/// <returns>A list of posts</returns>
-		public Listing<Post> Search(string terms, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All)
+        /// <summary>
+        /// Search using specific terms from a specified time to now
+        /// </summary>
+        /// <param name="terms">Terms you want to search for</param>
+        /// <param name="sortE">Sort the way you want to, see <see cref="Sorting"/></param>
+        /// <param name="timeE">Time sorting you want to see</param>
+        /// <returns>A list of posts</returns>
+        public Listing<Post> Search(string terms, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All)
         {
             string sort = sortE.ToString().ToLower();
             string time = timeE.ToString().ToLower();


### PR DESCRIPTION
The spam and edited queues allow moderators to get `Thing`s that have been removed by a moderator (or the spam filter or the admins) and the things that have been edited, respectively.

This change makes a minor revision to the `Subreddit` class adding two URL constants and two properties. The Obsolete getter methods have not been added.