### PR TITLE
Fixes formating and more descriptive error messages when editing a comment

### DIFF
--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -440,6 +440,10 @@ namespace RedditSharp
                 if (!captchaResponse.Cancel) // Keep trying until we are told to cancel
                     ComposePrivateMessage(subject, body, to, fromSubReddit, captchaId, captchaResponse.Answer);
             }
+            else if(json["json"]["errors"].Any())
+            {
+                throw new Exception("Error when composing message. Error: " + json["json"]["errors"][0][0].ToString());
+            }
         }
 
         /// <summary>

--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -302,7 +302,7 @@ namespace RedditSharp.Things
             if (json["json"].ToString().Contains("\"errors\": []"))
                 Body = newText;
             else
-                throw new Exception("Error editing text.");
+                throw new Exception("Error editing text. Error: " + json["json"]["errors"][0][0].ToString());
         }
 
         /// <summary>

--- a/RedditSharp/Things/LiveUpdateEvent.cs
+++ b/RedditSharp/Things/LiveUpdateEvent.cs
@@ -182,7 +182,7 @@ namespace RedditSharp.Things
             }
             else
             {
-                throw new Exception("Error editing text.");
+                throw new Exception("Error editing text. Error: " + json["json"]["errors"][0][0].ToString());
             }
         }
 
@@ -190,9 +190,9 @@ namespace RedditSharp.Things
         /// Get a list of contributors.
         /// </summary>
         /// <returns></returns>
-        public ICollection<LiveUpdateEvent.LiveUpdateEventUser> GetContributors()
+        public ICollection<LiveUpdateEventUser> GetContributors()
         {
-            var result = new List<LiveUpdateEvent.LiveUpdateEventUser>();
+            var result = new List<LiveUpdateEventUser>();
             var request = WebAgent.CreateGet(String.Format(ContributorsUrl, Name));
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -340,7 +340,7 @@ namespace RedditSharp.Things
             if (json["json"].ToString().Contains("\"errors\": []"))
                 SelfText = newText;
             else
-                throw new Exception("Error editing text.");
+                throw new Exception("Error editing text. Error: " + json["json"]["errors"][0][0].ToString());
         }
 
         /// <summary>

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -1096,6 +1096,10 @@ namespace RedditSharp.Things
             {
                 throw new DuplicateLinkException(string.Format("Post failed when submitting.  The following link has already been submitted: {0}", SubmitLinkUrl));
             }
+            else if(json["json"]["errors"].Any())
+            {
+                throw new Exception("Error when attempting to submit. Error: " + json["json"]["errors"][0][0].ToString());
+            }
 
             return new Post().Init(Reddit, json["json"], WebAgent);
         }
@@ -1130,7 +1134,10 @@ namespace RedditSharp.Things
             {
                 throw new DuplicateLinkException(string.Format("Post failed when submitting.  The following link has already been submitted: {0}", SubmitLinkUrl));
             }
-
+            else if (json["json"]["errors"].Any())
+            {
+                throw new Exception("Error when attempting to submit. Error: " + json["json"]["errors"][0][0].ToString());
+            }
             return new Post().Init(Reddit, json["json"], WebAgent);
         }
         /// <summary>


### PR DESCRIPTION
My goal here is to eventually be able to document all errors I get and then compile them into a general list of errors, this also allows for more descriptive errors than "I have an error", this also makes me not have to use fiddler to be able to get the errors when editing text