### PR TITLE
fixes #98

### DIFF
--- a/RedditSharp/Things/AuthenticatedUser.cs
+++ b/RedditSharp/Things/AuthenticatedUser.cs
@@ -125,11 +125,11 @@ namespace RedditSharp.Things
         /// <summary>
         /// Get a <see cref="Listing{T}"/> of messages in the inbox.
         /// </summary>
-        public Listing<PrivateMessage> Inbox
+        public Listing<Thing> Inbox
         {
             get
             {
-                return new Listing<PrivateMessage>(Reddit, InboxUrl, WebAgent);
+                return new Listing<Thing>(Reddit, InboxUrl, WebAgent);
             }
         }
 


### PR DESCRIPTION
The Reddit API returns both comments and private messages for a user's inbox. The previous code returned a listing of only private messages. This caused Issue #98. The simplest fix is to return a listing of things ( Listing<Thing> ) instead of a listing of private messages ( Listing<PrivateMessage> ) for the inbox. 