### PR TITLE
Changed PopulateObjectAsync to PopulateObject

### DIFF
--- a/RedditSharp/Moderator Actions/ModActionType.cs
+++ b/RedditSharp/Moderator Actions/ModActionType.cs
@@ -35,6 +35,8 @@ namespace RedditSharp
         SetSuggestedsort,
         Sticky,
         SpamComment,
+        Spoiler,
+        UnSpoiler,
         UnSticky,
         SetContestMode,
         UnSetContestMode,

--- a/RedditSharp/Moderator Actions/ModActionType.cs
+++ b/RedditSharp/Moderator Actions/ModActionType.cs
@@ -34,6 +34,7 @@ namespace RedditSharp
         SetPermissions,
         SetSuggestedsort,
         Sticky,
+        SpamComment,
         UnSticky,
         SetContestMode,
         UnSetContestMode,

--- a/RedditSharp/Things/AuthenticatedUser.cs
+++ b/RedditSharp/Things/AuthenticatedUser.cs
@@ -26,7 +26,7 @@ namespace RedditSharp.Things
         public new async Task<AuthenticatedUser> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             await CommonInitAsync(reddit, json, webAgent);
-            await JsonConvert.PopulateObjectAsync(json["name"] == null ? json["data"].ToString() : json.ToString(), this,
+            JsonConvert.PopulateObject(json["name"] == null ? json["data"].ToString() : json.ToString(), this,
                 reddit.JsonSerializerSettings);
             return this;
         }

--- a/RedditSharp/Things/BannedUser.cs
+++ b/RedditSharp/Things/BannedUser.cs
@@ -50,7 +50,7 @@ namespace RedditSharp.Things
         public async Task<BannedUser> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(json);
-            await JsonConvert.PopulateObjectAsync(json.ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -28,7 +28,7 @@ namespace RedditSharp.Things
         {
             var data = await CommonInitAsync(reddit, json, webAgent, sender);
             await ParseCommentsAsync(reddit, json, webAgent, sender);
-            await JsonConvert.PopulateObjectAsync(data.ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(data.ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/Contributor.cs
+++ b/RedditSharp/Things/Contributor.cs
@@ -44,7 +44,7 @@ namespace RedditSharp.Things
         public async Task<Contributor> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(json);
-            await JsonConvert.PopulateObjectAsync(json.ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/CreatedThing.cs
+++ b/RedditSharp/Things/CreatedThing.cs
@@ -30,7 +30,7 @@ namespace RedditSharp.Things
         protected async Task<CreatedThing> InitAsync(Reddit reddit, JToken json)
         {
             CommonInit(reddit, json);
-            await JsonConvert.PopulateObjectAsync(json["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json["data"].ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/LiveUpdate.cs
+++ b/RedditSharp/Things/LiveUpdate.cs
@@ -51,7 +51,7 @@ namespace RedditSharp.Things
         public async Task<LiveUpdate> InitAsync(Reddit reddit, JToken post, IWebAgent webAgent)
         {
             CommonInit(reddit, post, webAgent);
-            await JsonConvert.PopulateObjectAsync(post["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(post["data"].ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/LiveUpdateEvent.cs
+++ b/RedditSharp/Things/LiveUpdateEvent.cs
@@ -518,7 +518,7 @@ namespace RedditSharp.Things
         public async Task<LiveUpdateEvent> InitAsync(Reddit reddit, JToken post, IWebAgent webAgent)
         {
             CommonInit(reddit, post, webAgent);
-            await JsonConvert.PopulateObjectAsync(post["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(post["data"].ToString(), this, reddit.JsonSerializerSettings);
             FullName = Name;
             Name = Name.Replace("LiveUpdateEvent_", "");
             return this;

--- a/RedditSharp/Things/ModAction.cs
+++ b/RedditSharp/Things/ModAction.cs
@@ -123,7 +123,7 @@ namespace RedditSharp.Things
         public async Task<ModAction> InitAsync(Reddit reddit, JToken post, IWebAgent webAgent)
         {
             CommonInit(reddit, post, webAgent);
-            await JsonConvert.PopulateObjectAsync(post["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(post["data"].ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/More.cs
+++ b/RedditSharp/Things/More.cs
@@ -56,7 +56,7 @@ namespace RedditSharp.Things
 		internal async Task<Thing> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
 		{
 			CommonInit(reddit, json, webAgent);
-			await JsonConvert.PopulateObjectAsync(json["data"].ToString(), this, reddit.JsonSerializerSettings);
+			JsonConvert.PopulateObject(json["data"].ToString(), this, reddit.JsonSerializerSettings);
 			return this;	
 		}
 	}

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -34,7 +34,7 @@ namespace RedditSharp.Things
         public async Task<Post> InitAsync(Reddit reddit, JToken post, IWebAgent webAgent)
         {
             await CommonInitAsync(reddit, post, webAgent);
-            await JsonConvert.PopulateObjectAsync(post["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(post["data"].ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/PrivateMessage.cs
+++ b/RedditSharp/Things/PrivateMessage.cs
@@ -139,7 +139,7 @@ namespace RedditSharp.Things
         public async Task<PrivateMessage> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(reddit, json, webAgent);
-            await JsonConvert.PopulateObjectAsync(json["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json["data"].ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/RedditUser.cs
+++ b/RedditSharp/Things/RedditUser.cs
@@ -27,7 +27,7 @@ namespace RedditSharp.Things
         public async Task<RedditUser> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(reddit, json, webAgent);
-            await JsonConvert.PopulateObjectAsync(json["name"] == null ? json["data"].ToString() : json.ToString(), this,
+            JsonConvert.PopulateObject(json["name"] == null ? json["data"].ToString() : json.ToString(), this,
                 reddit.JsonSerializerSettings);
             return this;
         }

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -490,7 +490,7 @@ namespace RedditSharp.Things
         public async Task<Subreddit> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(reddit, json, webAgent);
-            await JsonConvert.PopulateObjectAsync(json["data"].ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json["data"].ToString(), this, reddit.JsonSerializerSettings);
             SetName();
 
             return this;

--- a/RedditSharp/Things/VotableThing.cs
+++ b/RedditSharp/Things/VotableThing.cs
@@ -58,7 +58,7 @@ namespace RedditSharp.Things
         protected async Task<VotableThing> InitAsync(Reddit reddit, IWebAgent webAgent, JToken json)
         {
             await CommonInitAsync(reddit, webAgent, json);
-            await JsonConvert.PopulateObjectAsync(json["data"].ToString(), this, Reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json["data"].ToString(), this, Reddit.JsonSerializerSettings);
             return this;
         }
 

--- a/RedditSharp/Things/WikiPageRevision.cs
+++ b/RedditSharp/Things/WikiPageRevision.cs
@@ -43,7 +43,7 @@ namespace RedditSharp.Things
         internal async Task<WikiPageRevision> InitAsync(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(reddit, json, webAgent);
-            await JsonConvert.PopulateObjectAsync(json.ToString(), this, reddit.JsonSerializerSettings);
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
             return this;
         }
         internal WikiPageRevision Init(Reddit reddit, JToken json, IWebAgent webAgent)


### PR DESCRIPTION
Newtonsoft JSON.net 10.0+ has removed PopulateObjectAsync() (and other Async methods) because it wasn't "truly async". This commit runs the synchronous method even when called asynchronously, so it can be used with libraries requiring JSON.net 10.0+ (like Discord.Net).