### PR TITLE
Shortlink fix.

### DIFF
--- a/RedditSharp/Things/Thing.cs
+++ b/RedditSharp/Things/Thing.cs
@@ -23,13 +23,6 @@ namespace RedditSharp.Things
             FetchedAt = DateTimeOffset.Now;
         }
 
-        /// <summary>
-        /// Shortlink to the item
-        /// </summary>
-        public virtual string Shortlink
-        {
-            get { return "http://redd.it/" + Id; }
-        }
 
         /// <summary>
         /// Base36 id.

--- a/RedditSharp/Things/VotableThing.cs
+++ b/RedditSharp/Things/VotableThing.cs
@@ -192,6 +192,14 @@ namespace RedditSharp.Things
         public bool Saved { get; set; }
 
         /// <summary>
+        /// Shortlink to the item
+        /// </summary>
+        public virtual string Shortlink
+        {
+            get { return "http://redd.it/" + Id; }
+        }
+
+        /// <summary>
         /// Returns true if the item is sticked.
         /// </summary>
         [JsonProperty("stickied")]


### PR DESCRIPTION
Shortlink field moved from Thing to VotableThing since only comments and
posts have valid shortlinks.