### PR TITLE
Fix Shortlinks.

### DIFF
--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -177,9 +177,10 @@ namespace RedditSharp.Things
                     linkId = this.LinkId.Substring(index + 1);
                 }
 
-                return string.Format("{0}://{1}/r/{2}/comments/{3}/_/{4}",
-                                     RedditSharp.WebAgent.Protocol, RedditSharp.WebAgent.RootDomain,
-                                     this.Subreddit, this.Parent != null ? this.Parent.Id : linkId, this.Id);
+                return string.Format("{0}://www.reddit.com/r/{1}/comments/{2}/_/{3}",
+                                     RedditSharp.WebAgent.Protocol,
+                                     this.Subreddit, this.Parent != null ? this.Parent.Id : linkId, 
+                                     this.Id);
             }
         }
 

--- a/RedditSharp/Things/Thing.cs
+++ b/RedditSharp/Things/Thing.cs
@@ -20,11 +20,6 @@ namespace RedditSharp.Things
         public AuthenticatedUser User { get; set; }
 
         /// <summary>
-        /// Shortlink to the item
-        /// </summary>
-        public virtual string Shortlink => "http://redd.it/" + Id;
-
-        /// <summary>
         /// Base36 id.
         /// </summary>
         public string Id { get; internal set; }

--- a/RedditSharp/Things/VotableThing.cs
+++ b/RedditSharp/Things/VotableThing.cs
@@ -75,6 +75,11 @@ namespace RedditSharp.Things
         public bool Saved { get; private set; }
 
         /// <summary>
+        /// Shortlink to the item
+        /// </summary>
+        public virtual string Shortlink => "http://redd.it/" + Id;
+
+        /// <summary>
         /// Returns true if the item is sticked.
         /// </summary>
         [JsonProperty("stickied")]


### PR DESCRIPTION
Put Shortlink into VotableThing and then fix the Shortlink for Comment.

Comment was putting "oath.reddit.com" into the Shortlink instead of "www.reddit.com" whenever the WebAgent was using oath.  I changed it so that it always uses "www.reddit.com".