### PR TITLE
Fixes #118

### DIFF
--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -237,9 +237,11 @@ namespace RedditSharp.Things
                     linkId = this.LinkId.Substring(index + 1);
                 }
 
-                return string.Format("{0}://{1}/r/{2}/comments/{3}/_/{4}",
-                                     RedditSharp.WebAgent.Protocol, RedditSharp.WebAgent.RootDomain,
-                                     this.Subreddit, this.Parent != null ? this.Parent.Id : linkId, this.Id);
+                return string.Format("{0}://www.reddit.com/r/{1}/comments/{2}/_/{3}",
+                                     RedditSharp.WebAgent.Protocol,
+                                     this.Subreddit, 
+                                     this.Parent != null ? this.Parent.Id : linkId, 
+                                     this.Id);
             }
         }
 


### PR DESCRIPTION
Shortlink fix for comments when using oath. If the WebAgent was using oath, then the shortlink contained "oath.reddit.com" instead of "www.reddit.com". I changed it so that it always uses "www.reddit.com".