### PR TITLE
Fixes to Listing<T>

### DIFF
--- a/RedditSharp/Listing.cs
+++ b/RedditSharp/Listing.cs
@@ -234,7 +234,8 @@ namespace RedditSharp
                     int limit = LimitPerRequest;
                     if (MaximumLimit > 0)
                     {
-                        limit = new[] { LimitPerRequest, MaximumLimit, Count + LimitPerRequest - MaximumLimit }.Min();
+                        limit = new[] { LimitPerRequest, MaximumLimit, (MaximumLimit - Count) }.Min();
+
                     }
                     if (limit > 0)
                     {

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -441,5 +441,17 @@ namespace RedditSharp
 
         #endregion SubredditSearching
 
+        /// <summary>
+        /// Create a listing from the specified url.  Useful if you want to specify your own "before" and "after" values.
+        /// </summary>
+        /// <typeparam name="T">A <see cref="RedditSharp.Things.Thing"/></typeparam>
+        /// <param name="url">endpoint url.</param>
+        /// <param name="maxLimit">Maximum number of records to retrieve from reddit.</param>
+        /// <param name="limitPerRequest">Maximum number of records to return per request.  This number is endpoint specific.</param>
+        /// <returns></returns>
+        public Listing<T> GetListing<T>(string url, int maxLimit = -1, int limitPerRequest = -1) where T : Thing
+        {
+            return new Listing<T>(this.WebAgent, url, maxLimit, limitPerRequest);
+        }
     }
 }


### PR DESCRIPTION
Adds a public method for instantiating a Listing at a specified endpoint.  This is useful when you want to specify your own "before" and "after" values.

Also fixes a problem where the limit url parameter was not being set correctly.