### PR TITLE
Fix static analysis issues

### DIFF
--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -165,7 +165,7 @@ namespace RedditSharp.Things
         public Thing Parent { get; internal set; }
 
 		/// <inheritdoc/>
-		public override string Shortlink => Permalink;
+		public override string Shortlink => Permalink.ToString();
 
         /// <summary>
         /// Reply to this comment.

--- a/RedditSharp/Things/LiveUpdateEvent.cs
+++ b/RedditSharp/Things/LiveUpdateEvent.cs
@@ -311,9 +311,10 @@ namespace RedditSharp.Things
         /// Remove a contributor from the live thread.
         /// </summary>
         /// <param name="userName">reddit username.</param>
-        public Task<bool> RemoveContributorAsync(string userName)
+        public async Task<bool> RemoveContributorAsync(string userName)
         {
-            return RemoveContributorAsync(userName);
+            var redditUser = await RedditUser.GetUserAsync(WebAgent, userName);
+            return await RemoveContributorAsync(redditUser).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -109,6 +109,7 @@ namespace RedditSharp
               await RateLimiter.CheckRateLimitAsync(IsOAuth).ConfigureAwait(false);
               response = await _httpClient.SendAsync(request()).ConfigureAwait(false);
               await RateLimiter.ReadHeadersAsync(response);
+              ++tries;
             } while( 
             //only retry if 500 or 503
                 (response.StatusCode == System.Net.HttpStatusCode.InternalServerError || 
@@ -229,7 +230,7 @@ namespace RedditSharp
             }
             for (int i = 0; i < additionalFields.Length; i += 2)
             {
-                var entry = Convert.ToString(additionalFields[i + 1]) ?? string.Empty;
+                var entry = Convert.ToString(additionalFields[i + 1]);
                 content.Add(new KeyValuePair<string, string>(additionalFields[i], entry));
             }
             //new FormUrlEncodedContent has a limit on length which can cause issues;


### PR DESCRIPTION
- [CS0029](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0029) Cannot implicitly convert type 'System.Uri' to 'string' RedditSharp\Things\Comment.cs 168
- [V3110](https://www.viva64.com/en/w/V3110) Possible infinite recursion inside 'RemoveContributorAsync' method. LiveUpdateEvent.cs 316
- [V3022](https://www.viva64.com/en/w/V3022) Expression 'Convert.ToString(additionalFields[i + 1])' is always not null. The operator '??' is excessive. WebAgent.cs 232
- [V3063](https://www.viva64.com/en/w/V3063) A part of conditional expression is always true if it is evaluated: tries < maxTries. WebAgent.cs 116

Analysed using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) as a part of [pinguem.ru](https://pinguem.ru) competition