### PR TITLE
Adding a basic expression based advanced search

### DIFF
--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -7,7 +7,9 @@ using System.Net;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
+using RedditSharp.Search;
 using DefaultWebAgent = RedditSharp.WebAgent;
+using System.Linq.Expressions;
 
 namespace RedditSharp
 {
@@ -42,6 +44,19 @@ namespace RedditSharp
         private const string GetLiveEventUrl = "https://www.reddit.com/live/{0}/about";
 
         #endregion
+        private IAdvancedSearchFormatter _searchFormatter;
+        private IAdvancedSearchFormatter SearchFormatter
+        {
+            get
+            {
+                if(_searchFormatter == null)
+                {
+                    _searchFormatter = new DefaultSearchFormatter();
+                }
+                return _searchFormatter;
+            }
+            set => _searchFormatter = value;
+        }
 
         
         internal IWebAgent WebAgent { get; set; }
@@ -625,6 +640,15 @@ namespace RedditSharp
             string time = timeE.ToString().ToLower();
             string final = string.Format(SearchUrl, queryBuilder.ToString(), sort, time);
             return new Listing<T>(this, final, WebAgent);
+        }
+
+        public Listing<Post> AdvancedSearch(Expression<Func<AdvancedSearchFilter, bool>> searchFilter, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All)
+        {
+            string query = SearchFormatter.Format(searchFilter);
+            string sort = sortE.ToString().ToLower();
+            string time = timeE.ToString().ToLower();
+            string final = string.Format(SearchUrl, query, sort, time);
+            return new Listing<Post>(this,final,WebAgent);
         }
 
         /// <summary>

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -662,7 +662,7 @@ namespace RedditSharp
         /// <param name="sortE">Order by <see cref="Sorting"/></param>
         /// <param name="timeE">Order by <see cref="TimeSorting"/></param>
         /// <returns></returns>
-        [Obsolete("time search was discontinued by reddit")]
+        [Obsolete("time search was discontinued by reddit",true)]
         public Listing<T> SearchByTimestamp<T>(DateTime from, DateTime to, string query = "", string subreddit = "", Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All) where T : Thing
         {
             return SearchByTimestamp<T>(new DateTimeOffset(from), new DateTimeOffset(to), query, subreddit, sortE, timeE);
@@ -679,7 +679,7 @@ namespace RedditSharp
         /// <param name="sortE">Order by <see cref="Sorting"/></param>
         /// <param name="timeE">Order by <see cref="TimeSorting"/></param>
         /// <returns></returns>
-        [Obsolete("time search was discontinued by reddit")]
+        [Obsolete("time search was discontinued by reddit",true)]
         public Listing<T> SearchByTimestamp<T>(DateTimeOffset from, DateTimeOffset to, string query = "", string subreddit = "", Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All) where T : Thing
         {
             string sort = sortE.ToString().ToLower();

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -51,6 +51,9 @@
   <ItemGroup>
     <Compile Include="BotWebAgent.cs" />
     <Compile Include="Flairs\FlairTemplate.cs" />
+    <Compile Include="Search\AdvancedSearch.cs" />
+    <Compile Include="Search\DefaultSearchFormatter.cs" />
+    <Compile Include="Search\ISearchFormatter.cs" />
     <Compile Include="Things\LiveUpdateEvent.cs" />
     <Compile Include="Things\LiveUpdate.cs" />
     <Compile Include="Moderator Actions\ModActionType.cs" />

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -53,7 +53,8 @@
     <Compile Include="Flairs\FlairTemplate.cs" />
     <Compile Include="Search\AdvancedSearch.cs" />
     <Compile Include="Search\DefaultSearchFormatter.cs" />
-    <Compile Include="Search\ISearchFormatter.cs" />
+    <Compile Include="Search\IAdvancedSearchFormatter.cs" />
+    <Compile Include="Search\SearchExpressionExtentions.cs" />
     <Compile Include="Things\LiveUpdateEvent.cs" />
     <Compile Include="Things\LiveUpdate.cs" />
     <Compile Include="Moderator Actions\ModActionType.cs" />

--- a/RedditSharp/Search/AdvancedSearch.cs
+++ b/RedditSharp/Search/AdvancedSearch.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedditSharp.Search
+{
+    public sealed class AdvancedSearchFilter
+    {
+        public string Author;
+        public string Flair;
+        public bool IsNsfw;
+        public bool IsSelf;
+        public string SelfText;
+        public string Site;
+        public string Subreddit;
+        public string Title;
+        public string Url;
+
+
+        private AdvancedSearchFilter() { }
+        
+
+    }
+}

--- a/RedditSharp/Search/DefaultSearchFormatter.cs
+++ b/RedditSharp/Search/DefaultSearchFormatter.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedditSharp.Search
+{
+    public class DefaultSearchFormatter : ISearchFormatter
+    {
+        string ISearchFormatter.Format(Expression<Func<AdvancedSearchFilter, bool>> search)
+        {
+            Expression expression = null;
+            Stack<Expression> expressionStack = new Stack<Expression>();
+            expressionStack.Push(search.Body);
+            Stack<string> searchStack = new Stack<string>();
+            while (expressionStack.Count > 0) {
+                expression = expressionStack.Pop();
+                switch (expression)
+                {
+                    case MemberExpression memberExpression:
+                        searchStack.Push(MemberExpressionHelper(memberExpression));
+                        break;
+                    case UnaryExpression unaryExpression:
+                        searchStack.Push(UnaryExpressionHelper(unaryExpression,expressionStack));
+                        break;
+                    case BinaryExpression binaryExpression:
+                        BinaryExpressionHelper(binaryExpression, expressionStack, searchStack);
+                        break;
+                    case ConstantExpression constantExpresssion:
+                        searchStack.Push(ConstantExpressionHelper(constantExpresssion));
+                        break;
+                    default:
+                        throw new NotImplementedException(expression.ToString());
+                }
+            }
+
+            string searchQuery = searchStack.Pop();
+            while(searchStack.Count > 0)
+            {
+                searchQuery = string.Format(searchStack.Pop(), searchQuery);
+            }
+            return searchQuery;
+        }
+
+        private string ConstantExpressionHelper(ConstantExpression constantExpresssion)
+        {
+            return constantExpresssion.ToString().Replace("\"","");
+        }
+
+        private void BinaryExpressionHelper(BinaryExpression expression, Stack<Expression> expressionStack, Stack<string> searchStack)
+        {
+            if(IsAdvancedSearchMemberExpression(expression.Left) && IsAdvancedSearchMemberExpression(expression.Right))
+            {
+                throw new InvalidOperationException("Cannot filter by comparing to fields.");
+            }
+            else if(IsAdvancedSearchMemberExpression(expression.Right))
+            {
+                expressionStack.Push(expression.Left);
+                expressionStack.Push(expression.Right);
+            }
+            else
+            {
+                expressionStack.Push(expression.Right);
+                expressionStack.Push(expression.Left);
+            }
+
+
+            if (expression.NodeType != ExpressionType.Equal)
+            {
+                searchStack.Push(expression.ToOperator());
+                //searchStack.Push("NOT(+{0}+)");
+            }
+            
+
+        }
+
+     
+        private string UnaryExpressionHelper(UnaryExpression expression, Stack<Expression> expressionStack)
+        {
+            string expressionOperator = expression.ToOperator();
+            expressionStack.Push(expression.Operand);
+            return expressionOperator;
+        }
+
+        private string MemberExpressionHelper(MemberExpression expression)
+        {
+            MemberInfo member = expression.Member;
+            string result = string.Empty;
+
+            if (member.DeclaringType == typeof(AdvancedSearchFilter))
+            {
+                result = member.Name.Replace(BOOL_PROPERTY_PREFIX, string.Empty).ToLower();
+                if (expression.Type == typeof(bool))
+                {
+                    result = result + ":1";
+                }
+                else
+                {
+                    result = result + ":{0}";
+                }
+
+            }
+            return result;
+        }
+
+
+        
+
+
+
+        private const string BOOL_PROPERTY_PREFIX = "Is";
+
+
+        private static readonly List<ExpressionType> conditionalTypes = new List<ExpressionType>()
+        {
+            ExpressionType.AndAlso,
+            ExpressionType.And,
+            ExpressionType.OrElse,
+            ExpressionType.Or
+        };
+
+        private static readonly List<ExpressionType> evaluateExpressions = new List<ExpressionType>()
+        {
+            ExpressionType.Add,
+            ExpressionType.Subtract,
+            ExpressionType.Multiply,
+            ExpressionType.Divide,
+            ExpressionType.Coalesce,
+            ExpressionType.Conditional
+        };
+
+        private static bool IsAdvancedSearchMemberExpression(Expression expression)
+        {
+            MemberExpression memberExpression = expression as MemberExpression;
+            return memberExpression?.Member.DeclaringType == typeof(AdvancedSearchFilter);
+        }
+    }
+
+    public static class Extensions
+    {
+        public static string ToOperator(this Expression expression)
+        {
+            ExpressionType? type = expression?.NodeType;
+            string result = string.Empty;
+            switch (type)
+            {
+                case ExpressionType.Not:
+                case ExpressionType.NotEqual:
+                    result = "NOT(+{0}+)";
+                    break;
+                case ExpressionType.Equal:
+                    result = ":";
+                    break;
+                case ExpressionType.AndAlso:
+                    result = "(+{0}+AND)";
+                    break;
+            }
+            return result;
+        }
+
+    }
+}

--- a/RedditSharp/Search/DefaultSearchFormatter.cs
+++ b/RedditSharp/Search/DefaultSearchFormatter.cs
@@ -38,7 +38,6 @@ namespace RedditSharp.Search
                 }
             }
 
-            string searchQuery = string.Empty;
             Stack<string> compoundSearchStack = new Stack<string>();
             while(formatInfoStack.Count >0)
             {
@@ -114,10 +113,23 @@ namespace RedditSharp.Search
                     
                 }
             }
+            else
+            {
+                searchStack.Push(InvokeGetExpression(expression).ToString());
+            }
         }
 
+        private static object InvokeGetExpression(Expression expression)
+        {
+            var objectMember = Expression.Convert(expression, typeof(object));
 
-        
+            var getterLambda = Expression.Lambda<Func<object>>(objectMember);
+
+            var getter = getterLambda.Compile();
+
+            return getter();
+        }
+
 
 
 

--- a/RedditSharp/Search/IAdvancedSearchFormatter.cs
+++ b/RedditSharp/Search/IAdvancedSearchFormatter.cs
@@ -5,14 +5,14 @@ using System.Linq.Expressions;
 
 namespace RedditSharp.Search
 {
-    public interface ISearchFormatter
+    public interface IAdvancedSearchFormatter
     {
 
         /// <summary>
-        /// 
+        /// use an expression to create a search for reddit
         /// </summary>
         /// <param name="search"></param>
-        /// <returns></returns>
+        /// <returns>the string representing the search expression in reddits search format</returns>
         /// <remarks>
         /// has to be Expression Func https://michael-mckenna.com/func-t-vs-expression-func-t-in-linq/
         /// </remarks>

--- a/RedditSharp/Search/ISearchFormatter.cs
+++ b/RedditSharp/Search/ISearchFormatter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace RedditSharp.Search
+{
+    public interface ISearchFormatter
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="search"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// has to be Expression Func https://michael-mckenna.com/func-t-vs-expression-func-t-in-linq/
+        /// </remarks>
+        string Format(Expression<Func<AdvancedSearchFilter, bool>> search);
+    }
+}

--- a/RedditSharp/Search/SearchExpressionExtentions.cs
+++ b/RedditSharp/Search/SearchExpressionExtentions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace RedditSharp.Search
+{
+    public static class SearchExtensions
+    {
+        internal static DefaultSearchFormatter.FormatInfo ToFormatInfo(this Expression expression)
+        {
+            ExpressionType? type = expression?.NodeType;
+            switch (type)
+            {
+                case ExpressionType.Not:
+                case ExpressionType.NotEqual:
+                    return DefaultSearchFormatter.FormatInfo.Not;
+                case ExpressionType.Equal:
+                    throw new NotImplementedException("Currently not supporting Equal expression.");
+                case ExpressionType.AndAlso:
+                    return DefaultSearchFormatter.FormatInfo.AndAlso;
+                case ExpressionType.MemberAccess:
+                    return DefaultSearchFormatter.FormatInfo.MemberAccess;
+                case ExpressionType.OrElse:
+                    return DefaultSearchFormatter.FormatInfo.OrElse;
+            }
+            throw new NotImplementedException($"{type.ToString()} is not implemented.");
+        }
+
+    }
+}

--- a/UnitTesting/AdvancedSearchTest.cs
+++ b/UnitTesting/AdvancedSearchTest.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using RedditSharp.Things;
+using RedditSharp;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Linq.Expressions;
+using RedditSharp.Search;
+namespace UnitTesting
+{
+
+    //q=subreddit:seattlewa+AND+((title:cat+AND+title:dog)+OR+(flair:sports+AND+NOT(+title:seahawks+)))&sort=new
+
+
+    [TestClass]
+    public class AdvancedSearchTest
+    {
+        [TestCategory("AdvancedSearch"),TestMethod]
+        public void BoolPropertyTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.IsNsfw;
+            string expected = "nsfw:1";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void NOT_BoolPropertyTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => !x.IsNsfw;
+            string expected = "NOT(+nsfw:1+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void StringPropertyTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Site == "google.com";
+            string expected = "site:google.com";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void Flipped_StringPropertyTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => "google.com" == x.Site;
+            string expected = "site:google.com";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void Not_StringPropertyTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Site != "google.com";
+            string expected = "NOT(+site:google.com+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void AndTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.IsNsfw && x.Site == "google.com";
+            string expected = "(+nsfw:1+AND+site:google.com+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+
+
+
+
+
+
+
+        //[TestMethod]
+        //public void ValueComparison_BoolPropertyTest()
+        //{
+        //    //Arrange
+        //    Expression<Func<AdvancedSearchFilter, bool>>
+        //        expression = x => !x.IsNsfw == true;
+        //    string expected = "NOT(+nsfw:1+)";
+
+        //    ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+        //    //Act
+        //    string actual = searchFormatter.Format(expression);
+
+        //    //Assert
+        //    Assert.AreEqual(expected, actual);
+        //}
+
+
+    }
+}

--- a/UnitTesting/AdvancedSearchTest.cs
+++ b/UnitTesting/AdvancedSearchTest.cs
@@ -110,7 +110,7 @@ namespace UnitTesting
 
         [TestMethod]
         [TestCategory("AdvancedSearch")]
-        public void AndTest()
+        public void AndAlsoTest()
         {
             //Arrange
             Expression<Func<AdvancedSearchFilter, bool>>
@@ -126,14 +126,81 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void TwoString_AndAlsoTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Author=="AutoModerator" && x.Site == "google.com";
+            string expected = "(+author:AutoModerator+AND+site:google.com+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void TwoString_OrElseTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Author == "AutoModerator" || x.Site == "google.com";
+            string expected = "(+author:AutoModerator+OR+site:google.com+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void NotOrElseTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => !(x.Author == "AutoModerator" || x.Site == "google.com");
+            string expected = "NOT(+(+author:AutoModerator+OR+site:google.com+)+)";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
 
 
+        [TestMethod]
+        [TestCategory("AdvancedSearch")]
+        public void AndNotOrElseTest()
+        {
+            //Arrange
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x =>  (x.Title != "trump") && !(x.Author == "AutoModerator" || x.Site == "google.com");
+            string expected = "(+NOT(+title:trump+)+AND+NOT(+(+author:AutoModerator+OR+site:google.com+)+)+)";
 
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
 
+            //Act
+            string actual = searchFormatter.Format(expression);
 
-
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
 
         //[TestMethod]
+        //[TestCategory("AdvancedSearch")]
         //public void ValueComparison_BoolPropertyTest()
         //{
         //    //Arrange

--- a/UnitTesting/AdvancedSearchTest.cs
+++ b/UnitTesting/AdvancedSearchTest.cs
@@ -199,6 +199,24 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
+        [TestCategory("AdvancedSearch"), TestMethod]
+        public void StringVariablePropertyTest()
+        {
+            //Arrange
+            string title = "meirl";
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Title == title;
+            string expected = "title:meirl";
+
+            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
         //[TestMethod]
         //[TestCategory("AdvancedSearch")]
         //public void ValueComparison_BoolPropertyTest()

--- a/UnitTesting/AdvancedSearchTest.cs
+++ b/UnitTesting/AdvancedSearchTest.cs
@@ -1,17 +1,9 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using RedditSharp.Things;
-using RedditSharp;
-using Newtonsoft.Json.Linq;
-using System.Linq;
 using System.Linq.Expressions;
 using RedditSharp.Search;
 namespace UnitTesting
 {
-
-    //q=subreddit:seattlewa+AND+((title:cat+AND+title:dog)+OR+(flair:sports+AND+NOT(+title:seahawks+)))&sort=new
-
 
     [TestClass]
     public class AdvancedSearchTest
@@ -24,7 +16,7 @@ namespace UnitTesting
                 expression = x => x.IsNsfw;
             string expected = "nsfw:1";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -33,9 +25,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void NOT_BoolPropertyTest()
         {
             //Arrange
@@ -43,7 +33,7 @@ namespace UnitTesting
                 expression = x => !x.IsNsfw;
             string expected = "NOT(+nsfw:1+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -52,9 +42,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void StringPropertyTest()
         {
             //Arrange
@@ -62,7 +50,7 @@ namespace UnitTesting
                 expression = x => x.Site == "google.com";
             string expected = "site:google.com";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -71,8 +59,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void Flipped_StringPropertyTest()
         {
             //Arrange
@@ -80,7 +67,7 @@ namespace UnitTesting
                 expression = x => "google.com" == x.Site;
             string expected = "site:google.com";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -89,9 +76,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void Not_StringPropertyTest()
         {
             //Arrange
@@ -99,7 +84,7 @@ namespace UnitTesting
                 expression = x => x.Site != "google.com";
             string expected = "NOT(+site:google.com+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -108,8 +93,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void AndAlsoTest()
         {
             //Arrange
@@ -117,7 +101,7 @@ namespace UnitTesting
                 expression = x => x.IsNsfw && x.Site == "google.com";
             string expected = "(+nsfw:1+AND+site:google.com+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -126,8 +110,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void TwoString_AndAlsoTest()
         {
             //Arrange
@@ -135,7 +118,7 @@ namespace UnitTesting
                 expression = x => x.Author=="AutoModerator" && x.Site == "google.com";
             string expected = "(+author:AutoModerator+AND+site:google.com+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -144,8 +127,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void TwoString_OrElseTest()
         {
             //Arrange
@@ -153,7 +135,7 @@ namespace UnitTesting
                 expression = x => x.Author == "AutoModerator" || x.Site == "google.com";
             string expected = "(+author:AutoModerator+OR+site:google.com+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -162,8 +144,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void NotOrElseTest()
         {
             //Arrange
@@ -171,7 +152,7 @@ namespace UnitTesting
                 expression = x => !(x.Author == "AutoModerator" || x.Site == "google.com");
             string expected = "NOT(+(+author:AutoModerator+OR+site:google.com+)+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -180,9 +161,7 @@ namespace UnitTesting
             Assert.AreEqual(expected, actual);
         }
 
-
-        [TestMethod]
-        [TestCategory("AdvancedSearch")]
+        [TestCategory("AdvancedSearch"), TestMethod]
         public void AndNotOrElseTest()
         {
             //Arrange
@@ -190,7 +169,7 @@ namespace UnitTesting
                 expression = x =>  (x.Title != "trump") && !(x.Author == "AutoModerator" || x.Site == "google.com");
             string expected = "(+NOT(+title:trump+)+AND+NOT(+(+author:AutoModerator+OR+site:google.com+)+)+)";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -208,7 +187,26 @@ namespace UnitTesting
                 expression = x => x.Title == title;
             string expected = "title:meirl";
 
-            ISearchFormatter searchFormatter = new DefaultSearchFormatter();
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
+
+            //Act
+            string actual = searchFormatter.Format(expression);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCategory("AdvancedSearch"), TestMethod]
+        public void ClassVariablePropertyTest()
+        {
+            //Arrange
+            Test t = new Test() { title = "meirl" };
+
+            Expression<Func<AdvancedSearchFilter, bool>>
+                expression = x => x.Title == t.title || x.Title == t.Title || x.Title == t.TitleMethod();
+            string expected = "(+(+title:meirl+OR+title:meirl+)+OR+title:meirl+)";
+
+            IAdvancedSearchFormatter searchFormatter = new DefaultSearchFormatter();
 
             //Act
             string actual = searchFormatter.Format(expression);
@@ -235,6 +233,14 @@ namespace UnitTesting
         //    Assert.AreEqual(expected, actual);
         //}
 
-
+        private class Test
+        {
+            public string title { get; set; }
+            public string Title => $"{title}";
+            public string TitleMethod()
+            {
+                return "meirl";
+            }
+        }
     }
 }

--- a/UnitTesting/UnitTesting.csproj
+++ b/UnitTesting/UnitTesting.csproj
@@ -67,6 +67,7 @@
     <Compile Include="TestData\More-3-4-5.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="AdvancedSearchTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RedditSharp\RedditSharp.csproj">


### PR DESCRIPTION
This will allow for compound queries that utilize fields in OR AND NOT conditionals as described https://www.reddit.com/wiki/search#wiki_boolean_operators.

Further expansion would be to allow more inline operations like null conditional operator, understanding things like String.Contains(), or Any().
